### PR TITLE
deps: revert protobuf to 3.19

### DIFF
--- a/proto-google-common-protos/build.gradle
+++ b/proto-google-common-protos/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.protobuf:protobuf-java:3.20.0'
+  compile 'com.google.protobuf:protobuf-java:3.19.4'
 }
 
 sourceSets {


### PR DESCRIPTION
Reverting for the sake of consistency.

This PR reverts https://github.com/googleapis/java-common-protos/commit/7c1b0dbe597790514064c6923c278c1020037471