### PR TITLE
deps: reverting protobuf java to 3.19 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-iam-parent</site.installationModule>
-    <protobuf.version>3.20.0</protobuf.version>
+    <protobuf.version>3.19.4</protobuf.version>
     <junit.version>4.13.2</junit.version>
     <grpc.version>1.45.1</grpc.version>
     <guava.version>31.0.1-android</guava.version>


### PR DESCRIPTION
It turned out that I have to modify the pom.xml for the protobuf version as well, in addition to #348 .

