### PR TITLE
feat: next release from main branch is 2.9.0

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -10,3 +10,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 2.6.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 2.8.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -47,6 +47,21 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - OwlBot Post Processor
+  - pattern: 2.8.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (8)
+      - dependencies (11)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
+      - OwlBot Post Processor
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
Release-brancher via go/backport-releases:

```
release-brancher create-pull-request \
  --branch-name="2.8.x" \
  --target-tag="v2.8.3" \
  --repo="googleapis/java-common-protos" \
  --pull-request-title="feat: next release from main branch is 2.9.0" \
  --release-type=java-backport --github-token ${GITHUB_TOKEN}
```
