### PR TITLE
chore: updating owlbot.py to exclude files

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -39,4 +39,6 @@ java.common_templates(excludes=[
   'samples/*',
   '.github/workflows/samples.yaml',
   '.kokoro/dependencies.sh',
+  '.github/ISSUE_TEMPLATE/bug_report.md',
+  '.github/ISSUE_TEMPLATE/feature_request.md'
 ])


### PR DESCRIPTION
This PR excludes the following files from owlbot's scope:

1) .github/ISSUE_TEMPLATE/bug_report.md
2) .github/ISSUE_TEMPLATE/feature_request.md

