### PR TITLE
chore: add java-docs-samples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 🚌 In January 2023, this library has moved to [gapic-generator-java/java-common-protos](https://github.com/googleapis/gapic-generator-java/tree/main/java-common-protos). This repository will be archived in the future. Future releases will appear in the new repository (https://github.com/googleapis/gapic-generator-java/releases).
 The Maven artifact coordinates (com.google.api.grpc:grpc-google-common-protos and com.google.api.grpc:proto-google-common-protos) remain the same.
+Sample code is in https://github.com/GoogleCloudPlatform/java-docs-samples.
 
 Java protobuf classes for Google's common protos.
 


### PR DESCRIPTION
The code in this repository has moved to https://github.com/googleapis/google-cloud-java/tree/main/java-common-protos and https://github.com/GoogleCloudPlatform/java-docs-samples